### PR TITLE
Fix Slow Performance or Crashing When Using MeshBuilder

### DIFF
--- a/include/mesh.h
+++ b/include/mesh.h
@@ -19,8 +19,12 @@ void prwmLoad(const char* filename);
 
 PRWmesh* prwmMeshGet(const char* meshName);
 
+uint32_t prwmGetGLTexture(PRWmesh* mesh);
+
+// deprecated: use prwmPutMesh(PRWmeshBuilder, PRWmesh) instead
 void prwmMeshRenderv(PRWmesh* mesh);
 
+// deprecated: use prwmPutMesh(PRWmeshBuilder, PRWmesh) instead
 void prwmMeshRender(const char* meshName);
 
 void prwmRemovev(PRWmesh* mesh);

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "mesh_builder.h"
+
 typedef struct PRWmesh
 {
     char name[256];
@@ -26,6 +28,8 @@ void prwmMeshRenderv(PRWmesh* mesh);
 
 // deprecated: use prwmPutMesh(PRWmeshBuilder, PRWmesh) instead
 void prwmMeshRender(const char* meshName);
+
+void prwmPutMesh(PRWmeshBuilder* meshBuilder, PRWmesh* mesh);
 
 void prwmRemovev(PRWmesh* mesh);
 

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -1,16 +1,18 @@
 #pragma once
 
-#define PRWM_VERTF_POS 0
-#define PRWM_VERTF_POS_UV 1
-#define PRWM_VERTF_POS_COLOR 2
-#define PRWM_VERTF_POS_UV_COLOR 3
-#define PRWM_VERTF_POS_UV_COLOR_NORM 4
-
 typedef struct PRWmesh
 {
-    int nbIndicies;
-    int vertexFormat;
-    char name[128];
+    char name[256];
+    float* positions;
+    size_t positionsSize;
+    float* uvs;
+    size_t uvsSize;
+    float* normals;
+    size_t normalsSize;
+    float* colors;
+    size_t colorsSize;
+    uint32_t* indicies;
+    size_t indiciesSize;
 } PRWmesh;
 
 void prwmLoad(const char* filename);

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -6,15 +6,12 @@ typedef struct PRWmesh
 {
     char name[256];
     float* positions;
-    size_t positionsSize;
+    size_t numVerticies;
     float* uvs;
-    size_t uvsSize;
     float* normals;
-    size_t normalsSize;
     float* colors;
-    size_t colorsSize;
     uint32_t* indicies;
-    size_t indiciesSize;
+    size_t numIndicies;
 } PRWmesh;
 
 void prwmLoad(const char* filename);

--- a/include/mesh.h
+++ b/include/mesh.h
@@ -26,7 +26,9 @@ void prwmMeshRenderv(PRWmesh* mesh);
 // deprecated: use prwmPutMesh(PRWmeshBuilder, PRWmesh) instead
 void prwmMeshRender(const char* meshName);
 
-void prwmPutMesh(PRWmeshBuilder* meshBuilder, PRWmesh* mesh);
+void prwmPutMeshArrays(PRWmeshBuilder* meshBuilder, PRWmesh* mesh);
+
+void prwmPutMeshElements(PRWmeshBuilder* meshBuilder, PRWmesh* mesh);
 
 void prwmRemovev(PRWmesh* mesh);
 

--- a/include/mesh_builder.h
+++ b/include/mesh_builder.h
@@ -105,6 +105,8 @@ void prwmbVertex(PRWmeshBuilder* builder, ...);
 
 void prwmbIndex(PRWmeshBuilder* builder, size_t numIndicies, ...);
 
+void prwmbIndexv(PRWmeshBuilder* builder, size_t numIndicies, const uint32_t* indicies);
+
 void prwmbTexid(PRWmeshBuilder* builder, uint8_t texid);
 
 prwvfVTXFMT* prwmbGetVertexFormat(PRWmeshBuilder* builder);

--- a/include/mesh_builder.h
+++ b/include/mesh_builder.h
@@ -107,7 +107,7 @@ void prwmbIndex(PRWmeshBuilder* builder, size_t numIndicies, ...);
 
 void prwmbIndexv(PRWmeshBuilder* builder, size_t numIndicies, const uint32_t* indicies);
 
-void prwmbTexid(PRWmeshBuilder* builder, uint8_t texid);
+void prwmbTexid(PRWmeshBuilder* builder, uint32_t texid);
 
 prwvfVTXFMT* prwmbGetVertexFormat(PRWmeshBuilder* builder);
 

--- a/mesh.c
+++ b/mesh.c
@@ -79,12 +79,13 @@ void prwmMeshRenderv(PRWmesh* mesh)
 
     prwmbReset(m_meshRenderer);
     uint32_t numIndicies = m->mesh.numIndicies;
+    float defaultUV[] = { 0.0f, 0.0f };
 
     for(uint32_t i = 0; i < numIndicies; i++)
     {
         uint32_t index = m->mesh.indicies[i];
         float* pos = &m->mesh.positions[index * 3];
-        float* uv = &m->mesh.uvs[index * 2];
+        float* uv = m->mesh.uvs ?  &m->mesh.uvs[index * 2] : defaultUV;
 
         prwmbVertex(m_meshRenderer, pos[0], pos[1], pos[2], uv[0], uv[1]);
     }

--- a/mesh.c
+++ b/mesh.c
@@ -102,6 +102,10 @@ void prwmRemovev(PRWmesh* mesh)
 {
     Mesh* m = (Mesh*) mesh;
     if(m->m_glTexture) glDeleteTextures(1, &m->m_glTexture);
+    if(m->mesh.positions) free(m->mesh.positions);
+    if(m->mesh.uvs) free(m->mesh.uvs);
+    if(m->mesh.normals) free(m->mesh.normals);
+    if(m->mesh.colors) free(m->mesh.colors);
 
     i_lRemove(m);
 }

--- a/mesh.c
+++ b/mesh.c
@@ -106,6 +106,7 @@ void prwmRemovev(PRWmesh* mesh)
     if(m->mesh.uvs) free(m->mesh.uvs);
     if(m->mesh.normals) free(m->mesh.normals);
     if(m->mesh.colors) free(m->mesh.colors);
+    if(m->mesh.indicies) free(m->mesh.indicies);
 
     i_lRemove(m);
 }

--- a/mesh.c
+++ b/mesh.c
@@ -78,7 +78,7 @@ void prwmMeshRenderv(PRWmesh* mesh)
     }
 
     prwmbReset(m_meshRenderer);
-    uint32_t numIndicies = m->mesh.indiciesSize;
+    uint32_t numIndicies = m->mesh.numIndicies;
 
     for(uint32_t i = 0; i < numIndicies; i++)
     {
@@ -182,16 +182,16 @@ static void i_meshLoadAssimp(const char* filename)
 
         strcpy(newMesh.mesh.name, mesh->mName.data);
 
+        newMesh.mesh.numVerticies = mesh->mNumVertices;
+
         //Get position data
-        newMesh.mesh.positionsSize = mesh->mNumVertices * 3;
-        newMesh.mesh.positions = malloc(sizeof(float) * newMesh.mesh.positionsSize);
-        memcpy(newMesh.mesh.positions, mesh->mVertices, sizeof(float) * newMesh.mesh.positionsSize);
+        newMesh.mesh.positions = malloc(sizeof(float) * mesh->mNumVertices * 3);
+        memcpy(newMesh.mesh.positions, mesh->mVertices, sizeof(float) * mesh->mNumVertices * 3);
 
         //Get uv data
         if(mesh->mTextureCoords[0])
         {
-            newMesh.mesh.uvsSize = mesh->mNumVertices * 2;
-            newMesh.mesh.uvs = malloc(sizeof(float) * newMesh.mesh.uvsSize);
+            newMesh.mesh.uvs = malloc(sizeof(float) * mesh->mNumVertices * 2);
             for(int j = 0; j < mesh->mNumVertices; j++)
             {
                 struct aiVector3D uv = mesh->mTextureCoords[0][j];
@@ -202,30 +202,26 @@ static void i_meshLoadAssimp(const char* filename)
         else
         {
             newMesh.mesh.uvs = NULL;
-            newMesh.mesh.uvsSize = 0;
         }
 
         //Get normal data
-        newMesh.mesh.normalsSize = mesh->mNumVertices * 3;
-        newMesh.mesh.normals = malloc(sizeof(float) * newMesh.mesh.normalsSize);
-        memcpy(newMesh.mesh.normals, mesh->mNormals, sizeof(float) * newMesh.mesh.normalsSize);
+        newMesh.mesh.normals = malloc(sizeof(float) * mesh->mNumVertices * 3);
+        memcpy(newMesh.mesh.normals, mesh->mNormals, sizeof(float) * mesh->mNumVertices * 3);
 
         //Get color data
         if(mesh->mColors[0])
         {
-            newMesh.mesh.colorsSize = mesh->mNumVertices * 4;
-            newMesh.mesh.colors = malloc(sizeof(float) * newMesh.mesh.colorsSize);
-            memcpy(newMesh.mesh.colors, mesh->mColors[0], sizeof(float) * newMesh.mesh.colorsSize);
+            newMesh.mesh.colors = malloc(sizeof(float) * mesh->mNumVertices * 4);
+            memcpy(newMesh.mesh.colors, mesh->mColors[0], sizeof(float) * mesh->mNumVertices * 4);
         }
         else
         {
             newMesh.mesh.colors = NULL;
-            newMesh.mesh.colorsSize = 0;
         }
 
         //Get index data
-        newMesh.mesh.indiciesSize = mesh->mNumFaces * 3;
-        newMesh.mesh.indicies = malloc(sizeof(uint32_t) * newMesh.mesh.indiciesSize);
+        newMesh.mesh.numIndicies = mesh->mNumFaces * 3;
+        newMesh.mesh.indicies = malloc(sizeof(uint32_t) * newMesh.mesh.numIndicies);
         for(int j = 0; j < mesh->mNumFaces; j++)
         {
             uint32_t* faceIndicies = mesh->mFaces[j].mIndices;

--- a/mesh.c
+++ b/mesh.c
@@ -31,21 +31,10 @@ static Mesh* i_lAdd(Mesh mesh);
 static void i_lRemove(Mesh* mesh);
 
 static void i_meshLoadAssimp(const char* filename);
-static void i_meshLoadBIN(const char* filename);
 
 void prwmLoad(const char* filename)
 {
-    char extension[24] = { 0 };
-    for(int i = strlen(filename) - 1; i >= 0; i--)
-        if(filename[i] == '.')
-        {
-            strcpy(extension, filename + i + 1);
-            break;
-        }
-
-    if(strcmp(extension, "bin") == 0) 
-        i_meshLoadBIN(filename);
-    else i_meshLoadAssimp(filename);
+    i_meshLoadAssimp(filename);
 }
 
 PRWmesh* prwmMeshGet(const char* meshName)
@@ -249,84 +238,4 @@ static void i_meshLoadAssimp(const char* filename)
 
         i_lAdd(newMesh);
     }
-}
-
-static void i_meshLoadBIN(const char* filename)
-{
-    struct MeshHeader
-    {
-        int verticiesArrayPtr, verticiesArraySize;
-	    int indiciesArrayPtr, indiciesArraySize;
-	    int texturePtr, textureWidth, textureHeight;
-    } MeshHeader;
-
-    FILE* file = fopen(filename, "rb");
-
-    if(file)
-    {
-        fseek(file, 0, SEEK_END);
-        size_t fileSize = ftell(file);
-
-        char* bufferedInput = malloc(fileSize);
-        rewind(file);
-        size_t ret = fread((char*) bufferedInput, fileSize, 1, file);
-        fclose(file);
-
-        char* bufferReadPtr = bufferedInput;
-    createMesh:
-        {
-            if(!*bufferReadPtr)
-            {
-                free(bufferedInput);
-                return;
-            }
-
-            Mesh mesh;
-            struct MeshHeader header;
-            memset(mesh.name, 0, sizeof(mesh.name));
-            mesh.vertexFormat = PRWM_VERTF_POS_UV;
-
-            strncpy(mesh.name, bufferReadPtr, sizeof(mesh.name) - 1);
-            bufferReadPtr += strlen(bufferReadPtr) + 1;
-
-            memcpy(&header.verticiesArrayPtr, bufferReadPtr, sizeof(int32_t) * 7);
-            bufferReadPtr += sizeof(int32_t) * 7;
-
-            const char* vertexData = bufferedInput + header.verticiesArrayPtr;
-            const char* indexData = bufferedInput + header.indiciesArrayPtr;
-            const char* textureData = bufferedInput + header.texturePtr;
-            mesh.nbIndicies = header.indiciesArraySize;
-
-            glGenVertexArrays(1, &mesh.glVAO);
-            glGenBuffers(2, &mesh.glVBO);
-            glGenTextures(1, &mesh.glTexture);
-
-            glBindVertexArray(mesh.glVAO);
-            {
-                glBindBuffer(GL_ARRAY_BUFFER, mesh.glVBO);
-                glBufferData(GL_ARRAY_BUFFER, header.verticiesArraySize * 20, vertexData, GL_STATIC_DRAW);
-                glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.glEBO);
-                glBufferData(GL_ELEMENT_ARRAY_BUFFER, header.indiciesArraySize * sizeof(uint32_t), indexData, GL_STATIC_DRAW);
-
-                glEnableVertexAttribArray(0);
-                glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 20, 0);
-                glEnableVertexAttribArray(1);
-                glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 20, (void*) 12);
-            }
-            glBindVertexArray(0);
-            glBindBuffer(GL_ARRAY_BUFFER, 0);
-            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-
-            glBindTexture(GL_TEXTURE_2D, mesh.glTexture);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, header.textureWidth, header.textureHeight, 0, GL_RGBA, GL_UNSIGNED_BYTE, textureData);
-
-            i_lAdd(mesh);
-            goto createMesh;
-        }
-    }
-    else printf("[BIN Mesh Loader][Error]: Unable to load %s\n", filename);
 }

--- a/mesh_builder.c
+++ b/mesh_builder.c
@@ -435,6 +435,32 @@ void prwmbIndex(PRWmeshBuilder* builder, size_t numIndicies, ...)
     b->m_numIndicies += numIndicies;
 }
 
+void prwmbIndexv(PRWmeshBuilder* builder, size_t numIndicies, const uint32_t* indicies)
+{
+    getMeshBuilder;
+
+    uint32_t bufferedIndicies[128];
+    size_t bufferedIndiciesPos = 0;
+
+    for(size_t i = 0; i < numIndicies; i++)
+    {
+        bufferedIndicies[bufferedIndiciesPos++] = indicies[i] + b->m_numVerticies;
+
+        if(128 <= bufferedIndiciesPos)
+        {
+            i_mbPushIndexData(b, bufferedIndiciesPos * sizeof(uint32_t), bufferedIndicies);
+            bufferedIndiciesPos = 0;
+        }
+    }
+
+    if(0 < bufferedIndiciesPos)
+    {
+        i_mbPushIndexData(b, bufferedIndiciesPos * sizeof(uint32_t), bufferedIndicies);
+    }
+
+    b->m_numIndicies += numIndicies;
+}
+
 void prwmbTexid(PRWmeshBuilder* builder, uint8_t texid)
 {
     getMeshBuilder;
@@ -446,7 +472,7 @@ prwvfVTXFMT* prwmbGetVertexFormat(PRWmeshBuilder* builder)
 {
     getMeshBuilder;
 
-    return &b->m_vertexFormat;
+    return &(b->m_vertexFormat);
 }
 
 void prwmbPushMatrix(PRWmeshBuilder* builder)

--- a/mesh_builder.c
+++ b/mesh_builder.c
@@ -461,7 +461,7 @@ void prwmbIndexv(PRWmeshBuilder* builder, size_t numIndicies, const uint32_t* in
     b->m_numIndicies += numIndicies;
 }
 
-void prwmbTexid(PRWmeshBuilder* builder, uint8_t texid)
+void prwmbTexid(PRWmeshBuilder* builder, uint32_t texid)
 {
     getMeshBuilder;
 

--- a/mesh_builder.c
+++ b/mesh_builder.c
@@ -229,7 +229,12 @@ void prwmbDrawArrays(PRWmeshBuilder* builder, int mode)
     glBindBuffer(GL_ARRAY_BUFFER, b->m_glVBO);
     if(b->m_vertexDataBufferCapacity <= b->m_glVertexBufferSize)
     {
+#ifdef EMSCRIPTEN
+        // Workaround. WebGL outputs a buffer overflow error when using glBufferSubData.
+        glBufferData(GL_ARRAY_BUFFER, b->m_glVertexBufferSize, b->m_vertexDataBuffer, GL_DYNAMIC_DRAW);
+#else
         glBufferSubData(GL_ARRAY_BUFFER, 0, b->m_vertexDataPos, b->m_vertexDataBuffer);
+#endif
     }
     else
     {
@@ -249,7 +254,12 @@ void prwmbDrawElements(PRWmeshBuilder* builder, int mode)
     glBindBuffer(GL_ARRAY_BUFFER, b->m_glVBO);
     if(b->m_vertexDataBufferCapacity <= b->m_glVertexBufferSize)
     {
+#ifdef EMSCRIPTEN
+        // Workaround. WebGL outputs a buffer overflow error when using glBufferSubData.
+        glBufferData(GL_ARRAY_BUFFER, b->m_glVertexBufferSize, b->m_vertexDataBuffer, GL_DYNAMIC_DRAW);
+#else
         glBufferSubData(GL_ARRAY_BUFFER, 0, b->m_vertexDataPos, b->m_vertexDataBuffer);
+#endif
     }
     else
     {
@@ -260,7 +270,12 @@ void prwmbDrawElements(PRWmeshBuilder* builder, int mode)
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, b->m_glEBO);
     if(b->m_indexDataBufferCapacity <= b->m_glElementBufferSize)
     {
+#ifdef EMSCRIPTEN
+        // Workaround. WebGL outputs a buffer overflow error when using glBufferSubData.
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, b->m_glElementBufferSize, b->m_indexDataBuffer, GL_DYNAMIC_DRAW);
+#else
         glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, b->m_indexDataPos, b->m_indexDataBuffer);
+#endif
     }
     else
     {

--- a/ui_render.c
+++ b/ui_render.c
@@ -253,7 +253,7 @@ static void i_init()
                     | PRWVF_ATTRB_NORMALIZED_FALSE;
 
     vertexFormat[4] = PRWVF_ATTRB_USAGE_TEXID
-                    | PRWVF_ATTRB_TYPE_UBYTE
+                    | PRWVF_ATTRB_TYPE_UINT
                     | PRWVF_ATTRB_SIZE(1)
                     | PRWVF_ATTRB_NORMALIZED_FALSE;
     


### PR DESCRIPTION
The MeshBuilder feature is important for rendering everything in this project. However, this recent feature fails to work in browser (when compiled with Emscripten), but it works fine in native Linux.

The problem is that WebGL is subtlety different than native OpenGL in some implementations which include (fixed in this PR):
* Vertex Attribute alignment when using `glVertexAttribPointer`. The stride and offset must be a multiple of the data type's size.
* `glBufferSubData` in WebGL does not fully work when using with Emscripten. The command causes a buffer overflow error, yet the application never tries to write further than the end of the buffer. So a temporary fix is made that is using `glBufferData` when updating the vertex buffer. If any fix or better workaround is found, it will be applied immediately.